### PR TITLE
feat: stop program when cell states were same in 2 consecutive steps #11

### DIFF
--- a/src/gameoflife.nim
+++ b/src/gameoflife.nim
@@ -247,8 +247,15 @@ File format:
     while true:
       echo "Press Ctrl-C to stop this program"
       echo "Step count: " & $steps
+
+      var beforeBoard = board
       board.nextStep()
       board.print()
+      if beforeBoard == board:
+        echo ""
+        echo "[INFO] Gameoflife has stopped because of cell states were same in 2 consecutive steps"
+        echo "[INFO] See you"
+        break
       cursorUp(board.len+2)
       inc steps
       sleep(200)


### PR DESCRIPTION
#11 

```
Press Ctrl-C to stop this program
Step count: 37
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|1|1|0|0|0|0|
|0|0|0|1|0|1|0|0|0|0|
|0|0|0|1|1|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|0|0|0|0|0|0|0|0|0|0|
|

[INFO] Gameoflife has stopped because of cell states were same in 2 censecutive steps
[INFO] See you
```